### PR TITLE
Add support for node v22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --provenance
         env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/melusc"
 	},
 	"engines": {
-		"node": "^18.17.1 || ^20.6.1"
+		"node": "^18.17.1 || ^20.6.1 || ^22.0.0"
 	},
 	"files": [
 		"tsconfig.json"


### PR DESCRIPTION
- Use node v22 to publish
- Add support for node v22 in engines.node
